### PR TITLE
Fix typos

### DIFF
--- a/decorators.rst
+++ b/decorators.rst
@@ -52,7 +52,7 @@ Vamos a ir un paso más allá. En Python podemos definir funciones dentro de otr
         print(bienvenida())
         print("De vuelta a la función hola()")
 
-    hi()
+    hola()
     #Salida:Estas dentro de la función hola()
     #       Estás dentro de la función saluda()
     #       Estás dentro de la función bienvenida()
@@ -115,7 +115,7 @@ Por último, podemos hacer que una función tenga a otra como entrada y que adem
         print("Hacer algo antes de llamar a func")
         print(func())
 
-    hazEstoAntesDeHola(hi)
+    hazEstoAntesDeHola(hola)
     #Salida: Hacer algo antes de llamar a func
     #        ¡Hola!
 

--- a/generators.rst
+++ b/generators.rst
@@ -117,7 +117,7 @@ Tal vez te preguntes porque no pasa esto cuando usamos un bucle ``for``. La resp
 .. code:: python
 
     cadena = "Pelayo"
-    next(my_string)
+    next(cadena)
     # Salida: cadena (most recent call last):
     #      File "<stdin>", line 1, in <module>
     #    TypeError: str object is not an iterator

--- a/global_&_return.rst
+++ b/global_&_return.rst
@@ -70,8 +70,8 @@ Tal vez quieras devolver más de una variable desde una función. Una primera fo
     def perfil():
         global nombre
         global edad
-        name = "Pelayo"
-        age = 30
+        nombre = "Pelayo"
+        edad = 30
 
     perfil()
     print(nombre)

--- a/global_&_return.rst
+++ b/global_&_return.rst
@@ -18,7 +18,7 @@ La función anterior toma dos argumentos de entrada y como salida devuelve su su
 
     def suma(valor1, valor2):
         global resultado
-        result = valor1 + valor2
+        resultado = valor1 + valor2
 
     suma(3,5)
     print(resultado)
@@ -43,7 +43,7 @@ Por otro lado, hemos visto como se puede hacer uso de ``global``. Por norma gene
     # fuera
     Traceback (most recent call last):
       File "", line 1, in
-        result
+        resultado
     NameError: name 'resultado' is not defined
 
     # Ahora vamos a hacer lo mismo pero declarando la función

--- a/ternary_operators.rst
+++ b/ternary_operators.rst
@@ -83,7 +83,7 @@ O también es una forma muy simple de definir parámetros con valores por defect
 .. code:: python
 
     >>> def mi_funcion(nombre_real, nombre_opcional=None):
-    >>>     nombre_opcional = optional_display_name or nombre_real
+    >>>     nombre_opcional = nombre_opcional or nombre_real
     >>>     print(nombre_opcional)
     >>> mi_funcion("Pelayo")
     Pelayo


### PR DESCRIPTION
Fixing some typos in decorators (`hi` to `hola`), generators (`my_string` to `cadena`) and ternary operators (`optional_display_name` to `nombre_opcional`)